### PR TITLE
Fixed proof printing, and implemented `read` and `write` in the `context` struct

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/context.h
+++ b/context.h
@@ -44,6 +44,24 @@ bool init(anaphora_binding& binding, unsigned int length) {
 	return binding.init(length);
 }
 
+template<typename Stream>
+bool read(anaphora_binding& binding, Stream& in, unsigned int length)
+{
+	if (!binding.init(length)) {
+		return false;
+	} else if (!read(binding.indices, in, length)) {
+		core::free(binding);
+		return false;
+	}
+	return true;
+}
+
+template<typename Stream>
+bool write(const anaphora_binding& binding, Stream& out, unsigned int length)
+{
+	return write(binding.indices, out, length);
+}
+
 struct context {
 	array<referent_iterator> referent_iterators;
 	array<anaphora_binding> bindings;
@@ -58,8 +76,8 @@ struct context {
 		core::free(ctx.bindings);
 	}
 
-	static inline bool clone(
-			const context& src, context& dst)
+	static inline bool clone(const context& src, context& dst,
+			hash_map<const hol_term*, hol_term*>& formula_map)
 	{
 		if (!array_init(dst.referent_iterators, src.referent_iterators.capacity)) {
 			return false;
@@ -69,7 +87,7 @@ struct context {
 		}
 
 		for (const referent_iterator& ref_iterator : src.referent_iterators) {
-			if (!referent_iterator::clone(ref_iterator, dst.referent_iterators[dst.referent_iterators.length])) {
+			if (!referent_iterator::clone(ref_iterator, dst.referent_iterators[dst.referent_iterators.length], formula_map)) {
 				core::free(dst);
 				return false;
 			}
@@ -93,5 +111,59 @@ private:
 			core::free(binding);
 	}
 };
+
+template<typename Formula>
+bool get_formula_map(const context& ctx, hash_map<const Formula*, unsigned int>& formula_map)
+{
+	for (const referent_iterator& iterator : ctx.referent_iterators)
+		if (!get_formula_map(iterator, formula_map)) return false;
+	return true;
+}
+
+template<typename Stream, typename Formula>
+bool read(context& ctx, Stream& in, Formula** formulas)
+{
+	size_t ref_iterator_count;
+	if (!read(ref_iterator_count, in)
+	 || !array_init(ctx.referent_iterators, ((size_t) 1) << (core::log2(ref_iterator_count == 0 ? 1 : ref_iterator_count) + 1)))
+	{
+		return false;
+	} else if (!array_init(ctx.bindings, ctx.referent_iterators.capacity)) {
+		core::free(ctx.referent_iterators);
+		return false;
+	}
+
+	for (size_t i = 0; i < ref_iterator_count; i++) {
+		if (!read(ctx.referent_iterators[ctx.referent_iterators.length], in, formulas)) {
+			core::free(ctx);
+			return false;
+		}
+		ctx.referent_iterators.length++;
+	} for (size_t i = 0; i < ref_iterator_count; i++) {
+		if (!read(ctx.bindings[ctx.bindings.length], in, ctx.referent_iterators[i].anaphora.size)) {
+			core::free(ctx);
+			return false;
+		}
+		ctx.bindings.length++;
+	}
+	return true;
+}
+
+template<typename Stream, typename Formula>
+bool write(const context& ctx, Stream& out,
+		const hash_map<const Formula*, unsigned int>& formula_map)
+{
+	if (!write(ctx.referent_iterators.length, out))
+		return false;
+
+	for (size_t i = 0; i < ctx.referent_iterators.length; i++) {
+		if (!write(ctx.referent_iterators[i], out, formula_map))
+			return false;
+	} for (size_t i = 0; i < ctx.bindings.length; i++) {
+		if (!write(ctx.bindings[i], out, ctx.referent_iterators[i].anaphora.size))
+			return false;
+	}
+	return true;
+}
 
 #endif /* CONTEXT_H_ */

--- a/higher_order_logic.h
+++ b/higher_order_logic.h
@@ -3062,6 +3062,8 @@ hol_term* default_apply(hol_term* src, Function&&... function)
 		if (!changed) {
 			free(new_terms);
 			return src;
+		} else if (new_terms == NULL) {
+			return NULL;
 		} else {
 			if (!new_hol_term(new_term)) {
 				for (unsigned int j = 0; j < src->array.length; j++) {
@@ -3700,7 +3702,7 @@ inline hol_term* apply(hol_term* src, index_substituter& substituter)
 inline hol_term* substitute(
 		hol_term* src, const unsigned int* term_indices,
 		unsigned int term_index_count, hol_term* dst_term,
-		const hol_term* expected_src_term = NULL)
+		const hol_term* expected_src_term = nullptr)
 {
 	index_substituter substituter = {expected_src_term, dst_term, term_indices, term_index_count, 0};
 	hol_term* term = apply(src, substituter);
@@ -3720,7 +3722,7 @@ struct beta_reducer {
 inline hol_term* beta_reduce(hol_term* left_src, hol_term* right_src, beta_reducer& reducer)
 {
 	hol_term* right = apply(right_src, reducer);
-	if (right == NULL) return NULL;
+	if (right == nullptr) return nullptr;
 	else if (right == right_src)
 		right->reference_count++;
 
@@ -3729,12 +3731,12 @@ inline hol_term* beta_reduce(hol_term* left_src, hol_term* right_src, beta_reduc
 		reducer.max_variable = max(reducer.max_variable, left_src->quantifier.variable);
 		if (!reducer.substitutions.put(left_src->quantifier.variable, right)) {
 			free(*right); if (right->reference_count == 0) free(right);
-			return NULL;
+			return nullptr;
 		}
 
 		result = apply(left_src->quantifier.operand, reducer);
 		free(*right); if (right->reference_count == 0) free(right);
-		if (result == NULL) return NULL;
+		if (result == nullptr) return nullptr;
 		else if (result == left_src->quantifier.operand)
 			result->reference_count++;
 #if !defined(NDEBUG)
@@ -3745,9 +3747,9 @@ inline hol_term* beta_reduce(hol_term* left_src, hol_term* right_src, beta_reduc
 #endif
 	} else {
 		hol_term* left = apply(left_src, reducer);
-		if (left == NULL) {
+		if (left == nullptr) {
 			free(*right); if (right->reference_count == 0) free(right);
-			return NULL;
+			return nullptr;
 		} else if (left == left_src)
 			left->reference_count++;
 
@@ -3760,18 +3762,18 @@ inline hol_term* beta_reduce(hol_term* left_src, hol_term* right_src, beta_reduc
 
 			result = apply(left->quantifier.operand, new_reducer);
 			free(*right); if (right->reference_count == 0) free(right);
-			if (result == NULL) {
+			if (result == nullptr) {
 				free(*left); if (left->reference_count == 0) free(left);
-				return NULL;
+				return nullptr;
 			} else if (result == left->quantifier.operand)
 				result->reference_count++;
 			free(*left); if (left->reference_count == 0) free(left);
 		} else {
 			result = hol_term::new_apply(left, right);
-			if (result == NULL) {
+			if (result == nullptr) {
 				free(*right); if (right->reference_count == 0) free(right);
 				free(*left); if (left->reference_count == 0) free(left);
-				return NULL;
+				return nullptr;
 			}
 		}
 	}

--- a/natural_deduction.h
+++ b/natural_deduction.h
@@ -1638,7 +1638,10 @@ bool check_proof(proof_state<Formula>& out,
 			return false;
 		}
 
-		if (formula == NULL) return false;
+		if (formula == NULL) {
+			fprintf(stderr, "check_proof ERROR: Invalid term indices for substitution.\n");
+			return false;
+		}
 		out.formula = Formula::new_exists(1, formula);
 		if (out.formula == NULL) {
 			free(*formula); if (formula->reference_count == 0) free(formula);

--- a/pwl_reasoner.cpp
+++ b/pwl_reasoner.cpp
@@ -240,7 +240,7 @@ T.print_disjunction_introductions(stdout, *debug_terminal_printer); fflush(stdou
 		auto collector = make_log_probability_collector(T, proof_prior, new_proof);
 		double max_log_probability = collector.current_log_probability;
 		for (unsigned int j = 0; j < 4; j++) {
-			for (unsigned int t = 0; t < 1000; t++) {
+			for (unsigned int t = 0; t < 500; t++) {
 //fprintf(stderr, "i = %u, j = %u, t = %u\n", i, j, t);
 //if (!check_consistency(T, proof_axioms, collector, i, j, t, "intermediate MCMC")) exit(EXIT_FAILURE);
 /*T.template print_axioms<true>(stdout, *debug_terminal_printer);
@@ -278,7 +278,7 @@ debug_flag = false;
 		T_MAP.template print_axioms<true>(stdout, *debug_terminal_printer);
 		print("Theory log probability: ", stdout); print(max_log_probability, stdout); print("\n", stdout);
 		print("Proof of newly-added logical form in the best theory:\n", stdout);
-		print<built_in_predicates, polymorphic_canonicalizer<true, false, built_in_predicates>, false>(*T.observations.last(), stdout, *debug_terminal_printer);
+		print<built_in_predicates, identity_canonicalizer, false>(*T.observations.last(), stdout, *debug_terminal_printer);
 		print('\n', stdout); fflush(stdout);
 		free(T_MAP); free(proof_axioms_MAP);
 	}

--- a/theory.h
+++ b/theory.h
@@ -4336,7 +4336,7 @@ struct theory
 			core::free(*dst.empty_set_axiom); if (dst.empty_set_axiom->reference_count == 0) core::free(dst.empty_set_axiom);
 			core::free(*dst.NAME_ATOM); if (dst.NAME_ATOM->reference_count == 0) core::free(dst.NAME_ATOM);
 			return false;
-		} else if (!context::clone(src.ctx, dst.ctx)) {
+		} else if (!context::clone(src.ctx, dst.ctx, formula_map)) {
 			core::free(dst.implication_intro_nodes);
 			core::free(dst.negated_conjunction_nodes);
 			core::free(dst.disjunction_intro_nodes);
@@ -16374,7 +16374,8 @@ bool get_proof_map(const theory<ProofCalculus, Canonicalizer>& T,
 
 	if (!get_proof_map(T.empty_set_axiom, proof_map, formula_map)
 	 || !get_formula_map(T.NAME_ATOM, formula_map)
-	 || !get_proof_map(T.sets, proof_map, formula_map))
+	 || !get_proof_map(T.sets, proof_map, formula_map)
+	 || !get_formula_map(T.ctx, formula_map))
 	{
 		return false;
 	}
@@ -16443,7 +16444,8 @@ bool read(theory<ProofCalculus, Canonicalizer>& T, Stream& in,
 	 || !read(built_in_axiom_count, in)
 	 || !read(empty_set_axiom_index, in)
 	 || !read(NAME_ATOM_index, in)
-	 || !read(T.sets, in, proofs, formulas))
+	 || !read(T.sets, in, proofs, formulas)
+	 || !read(T.ctx, in, formulas))
 	{
 		return false;
 	} else if (!read(atom_count, in)) {


### PR DESCRIPTION
Fixed bug in proof printing in `pwl_reasoner.cpp`. Also implemented the `read` and `write` functions for the context struct (and member structs), and appropriately modified the `clone` functions.