### PR TITLE
Fixed bug during MCMC where not all provable elements are correctly removed after removing a subset axiom 

### DIFF
--- a/natural_deduction_mh.h
+++ b/natural_deduction_mh.h
@@ -2096,7 +2096,7 @@ print(*selected_proof_step.formula, stderr); print('\n', stderr);
 		sampler.clear();
 if (debug_flag) {
 fprintf(stderr, "INNER DEBUG: %u\n", debug);
-T.print_axioms(stderr, *debug_terminal_printer);
+T.template print_axioms<true>(stderr, *debug_terminal_printer);
 }
 debug++;
 		new_set_diff.clear();
@@ -2109,7 +2109,7 @@ debug++;
 	}
 if (debug_flag) {
 fprintf(stderr, "INNER DEBUG: %u (loop broken)\n", debug);
-T.print_axioms(stderr, *debug_terminal_printer);
+T.template print_axioms<true>(stderr, *debug_terminal_printer);
 }
 
 	log_proposal_probability_ratio -= sampler.log_probability;


### PR DESCRIPTION
Fixed a bug where if a subset axiom were removed, some elements may be removed from the `provable_elements` arrays of the consequent set (and its supersets), but we were not correctly checking whether removing these provable elements would make other things no longer provable.