### PR TITLE
Fixed two bugs:

### DIFF
--- a/pwl_reasoner.cpp
+++ b/pwl_reasoner.cpp
@@ -207,7 +207,11 @@ set_seed(1356941742);
 //fprintf(stderr, "(add_formula) j = %u, t = %u\n", j, t);
 if (!check_consistency(T, proof_axioms, collector, i, j, t, "add_formula")) exit(EXIT_FAILURE);
 /*T.template print_axioms<true>(stdout, *debug_terminal_printer);
-T.print_disjunction_introductions(stdout, *debug_terminal_printer); fflush(stdout);*/
+T.print_disjunction_introductions(stdout, *debug_terminal_printer); fflush(stdout);
+if (i == 13 && j == 76 && t == 2) {
+fprintf(stderr, "DEBUG\n");
+debug_flag = true;
+}*/
 				do_exploratory_mh_step(T, proof_prior, proof_axioms, collector);
 			}
 			new_proof = T.add_formula(lf, set_diff, new_constant);
@@ -250,7 +254,7 @@ T.print_disjunction_introductions(stdout, *debug_terminal_printer); fflush(stdou
 if (!check_consistency(T, proof_axioms, collector, i, j, t, "intermediate MCMC")) exit(EXIT_FAILURE);
 /*T.template print_axioms<true>(stdout, *debug_terminal_printer);
 T.print_disjunction_introductions(stdout, *debug_terminal_printer); fflush(stdout);
-if (i == 6 && j == 0 && t == 173) {
+if (i == 10 && j == 0 && t == 4) {
 fprintf(stderr, "DEBUG\n");
 debug_flag = true;
 } else {


### PR DESCRIPTION
 1. PWL was not correctly handling logical forms of the form ~?[x]:(f(x) & g(x)) even though it was correctly handling those of the form ![x]:(f(x) => ~g(x)). More specifically, it was not able to use axioms containing ~?[x]:(f(x) & g(x)) to prove ~g(x) for other values of x.
 2. PWL was incorrectly filtering constants when instantiating the existential quantifier in ~?[x]:(X(x) & x=y) since it was being canonicalized into the form ~X(y).