### PR TITLE
Small bug fix and enabling MCMC hyperparameters to be specified in command-line

### DIFF
--- a/article.h
+++ b/article.h
@@ -70,7 +70,7 @@ inline bool init(sentence<Derivation>& dst, const sentence<Derivation>& src) {
 	if (src.tokens == nullptr) {
 		dst.tokens = nullptr;
 	} else {
-		dst.tokens = (sentence_token*) malloc(max((size_t) 1, sizeof(sentence_token) * src.length));
+		dst.tokens = (sentence_token*) malloc(sizeof(sentence_token) * max((size_t) 1, src.length));
 		if (dst.tokens == NULL) {
 			fprintf(stderr, "init ERROR: Insufficient memory for sentence.tokens.\n");
 			return false;

--- a/lf_utils.h
+++ b/lf_utils.h
@@ -2526,7 +2526,7 @@ inline hol_term* apply(hol_term* src, comparative_normalizer& normalizer)
 					hol_term* other_arg1 = nullptr; hol_term* other_arg1_of = nullptr;
 					hol_term* other_arg2 = nullptr; hol_term* other_arg2_of = nullptr;
 					hol_term* other_predicate = nullptr;
-					unsigned int predicate_index, arg1_index, arg2_index;
+					unsigned int predicate_index = -1, arg1_index = -1, arg2_index = -1;
 					if (other_operand->type == hol_term_type::AND) {
 						predicate_index = other_operand->array.length;
 						arg1_index = other_operand->array.length;

--- a/natural_deduction_mh.h
+++ b/natural_deduction_mh.h
@@ -3242,6 +3242,7 @@ bool propose_rebind_anaphora(
 	Proof* new_proof;
 	proof_sampler<ProposalDistribution::IsExploratory> sampler;
 	set_changes<Formula> new_set_diff;
+	get_proof_disjunction_nodes(proof, sampler.old_proof);
 	unsigned int old_referent_id = T.ctx.bindings[sentence_id].indices[anaphora_id];
 	while (true) {
 		unsigned int new_referent_id = sample_uniform(anaphora_start);

--- a/pwl_reasoner.cpp
+++ b/pwl_reasoner.cpp
@@ -132,8 +132,8 @@ set_seed(1356941742);
 	unsigned int retry_attempts = 100;
 	unsigned int iterations_per_retry = 10;
 	unsigned int num_reheating_phases = 4;
-	unsigned int iterations_per_reheat = 500;
-	unsigned int reheating_iterations = 40;
+	unsigned int iterations_per_reheat = 800;
+	unsigned int reheating_iterations = 200;
 
 	/* parse the optional command-line arguments */
 	if (argc > 2 && !parse_uint(string(argv[2]), retry_attempts)) {


### PR DESCRIPTION
Fixed a bug in the MH proposal for rebinding anaphora which would very rarely cause a segfault.

Also, changed `pwl_reasoner` to take command-line arguments to specify MCMC hyperparameters. I changed the default values to increase the number of MCMC iterations.